### PR TITLE
INCOMPLETE: Added profit field for overlay with profit calculation 

### DIFF
--- a/src/main/java/com/wikiworm/inventoryvalue/InventoryValueOverlay.java
+++ b/src/main/java/com/wikiworm/inventoryvalue/InventoryValueOverlay.java
@@ -42,6 +42,7 @@ import java.awt.*;
  */
 public class InventoryValueOverlay extends Overlay {
     private Long inventoryValue;
+    private long profitValue;
     private final InventoryValueConfig ivConfig;
     private final PanelComponent panelComponent = new PanelComponent();
 
@@ -51,6 +52,7 @@ public class InventoryValueOverlay extends Overlay {
         // TODO -- this should be part of config...
         setPosition(OverlayPosition.ABOVE_CHATBOX_RIGHT);
         inventoryValue = 0L;
+        profitValue = 0L;
         ivConfig = config;
     }
 
@@ -84,6 +86,12 @@ public class InventoryValueOverlay extends Overlay {
                 .right(Long.toString(inventoryValue))
                 .build());
 
+        // Profit
+        panelComponent.getChildren().add(LineComponent.builder()
+                .left("Profit:")
+                .right(Long.toString(profitValue))
+                .build());
+
         return panelComponent.render(graphics);
     }
 
@@ -95,6 +103,20 @@ public class InventoryValueOverlay extends Overlay {
         SwingUtilities.invokeLater(() -> {
             inventoryValue = newValue;
         });
+
+
+    }
+
+    /**
+     * Updates profit value display
+     * @param newValue the value to update the profitValue's {{@link #panelComponent}} with.
+     */
+    public void updateProfitValue(final long newValue) {
+        SwingUtilities.invokeLater(() -> {
+            profitValue = newValue;
+        });
+
+
     }
 
 

--- a/src/main/java/com/wikiworm/inventoryvalue/InventoryValueOverlay.java
+++ b/src/main/java/com/wikiworm/inventoryvalue/InventoryValueOverlay.java
@@ -36,6 +36,7 @@ import javax.inject.Inject;
 import javax.swing.*;
 import java.awt.*;
 
+import java.text.DecimalFormat;
 /**
  * The InventoryValueOverlay class is used to display the value of the users inventory as an overlay
  * on the RuneLite client gameplay panel.
@@ -46,6 +47,10 @@ public class InventoryValueOverlay extends Overlay {
     private final InventoryValueConfig ivConfig;
     private final PanelComponent panelComponent = new PanelComponent();
 
+    public static String FormatIntegerWithCommas(long value) {
+        DecimalFormat df = new DecimalFormat("###,###,###");
+        return df.format(value);
+    }
     @Inject
     private InventoryValueOverlay(InventoryValueConfig config)
     {
@@ -83,13 +88,13 @@ public class InventoryValueOverlay extends Overlay {
         // Build line on the overlay for world number
         panelComponent.getChildren().add(LineComponent.builder()
                 .left(valueString)
-                .right(Long.toString(inventoryValue))
+                .right(FormatIntegerWithCommas(inventoryValue))
                 .build());
 
         // Profit
         panelComponent.getChildren().add(LineComponent.builder()
                 .left("Profit:")
-                .right(Long.toString(profitValue))
+                .right(FormatIntegerWithCommas(profitValue))
                 .build());
 
         return panelComponent.render(graphics);


### PR DESCRIPTION
I opened this pull request to check if you are interested in such features related to profit tracking,
that will calculate how much profit you've made, per hour, in total, including items you've just banked
for people going on money making.
I added a profit field for starters:
![image](https://user-images.githubusercontent.com/8212109/93921978-fe427780-fd19-11ea-8ff3-cb9cbef42fdd.png)
