### PR TITLE
add ability to exclude items from inventory value calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,19 @@ Available as part of the plugin-hub. Search "Inventory Value Overlay" on plugin-
 
 ## Configuration Options
 
-![Configuration](https://raw.githubusercontent.com/wikiworm/InventoryValue/dev/screenshots/inventory_value_config_ss.PNG "Configuration")
+![Configuration](https://user-images.githubusercontent.com/5294864/102701144-eea3d380-4221-11eb-9b66-bbb6d91408b3.png "Configuration")
 
 ### Use HighAlchemy Value
 When checked, the inventory values calculation will use the coin value received from casting high alchemy on the item.
 
 ### Ignore Coins
 When checked, the inventory value calculation will ignore coins in the user's inventory.
+
+### Ignore Items
+When a comma or semicolon separated list of item names is provided, those items will not be included in the inventory value.
+
+![Ignoring Items](https://user-images.githubusercontent.com/5294864/102701261-2b23ff00-4223-11eb-97c6-0ccc197d2896.png)
+![Ignored Item Demonstration](https://user-images.githubusercontent.com/5294864/102701219-a802a900-4222-11eb-9aa7-6d5424ca0d47.png)
 
 # Building the Plugin
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ When checked, the inventory value calculation will ignore coins in the user's in
 When a comma or semicolon separated list of item names is provided, those items will not be included in the inventory value.
 
 ![Ignoring Items](https://user-images.githubusercontent.com/5294864/102701261-2b23ff00-4223-11eb-97c6-0ccc197d2896.png)
-![Ignored Item Demonstration](https://user-images.githubusercontent.com/5294864/102701219-a802a900-4222-11eb-9aa7-6d5424ca0d47.png)
+![image](https://user-images.githubusercontent.com/5294864/102736363-bcbe6a00-4312-11eb-8417-bf0d69f517ac.png)
 
 # Building the Plugin
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
     mavenCentral()
 }
 
-def runeLiteVersion = '1.6.26.1'
+def runeLiteVersion = '1.6.35'
 
 dependencies {
     compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/build.gradle
+++ b/build.gradle
@@ -18,15 +18,17 @@ dependencies {
     compileOnly 'org.projectlombok:lombok:1.18.4'
     annotationProcessor 'org.projectlombok:lombok:1.18.4'
 
+    testCompile 'org.mockito:mockito-core:2.7.22'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.slf4j:slf4j-simple:1.7.12'
+    testImplementation 'com.google.inject.extensions:guice-testlib:4.1.0'
     testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion, {
         exclude group: 'ch.qos.logback', module: 'logback-classic'
     }
 }
 
 group = 'com.wikiworm.inventoryvalue'
-version = '1.0'
+version = '1.1'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/com/wikiworm/inventoryvalue/InventoryValueConfig.java
+++ b/src/main/java/com/wikiworm/inventoryvalue/InventoryValueConfig.java
@@ -1,40 +1,10 @@
-/*
- *  BSD 2-Clause License
- *
- *  Copyright (c) 2020, wikiworm (Brandon Ripley)
- *  All rights reserved.
- *
- *  Redistribution and use in source and binary forms, with or without
- *  modification, are permitted provided that the following conditions are met:
- *
- *  1. Redistributions of source code must retain the above copyright notice, this
- *     list of conditions and the following disclaimer.
- *
- *  2. Redistributions in binary form must reproduce the above copyright notice,
- *     this list of conditions and the following disclaimer in the documentation
- *     and/or other materials provided with the distribution.
- *
- *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- *  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- *  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- *  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- *  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
 package com.wikiworm.inventoryvalue;
 
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 
-/**
- * The InventoryValueConfig class is used to provide user preferences to the InventoryValuePlugin.
- */
-@ConfigGroup("ivconfig")
+@ConfigGroup("inventoryValue")
 public interface InventoryValueConfig extends Config
 {
     @ConfigItem(
@@ -42,19 +12,19 @@ public interface InventoryValueConfig extends Config
             name = "Use High Alchemy Value",
             description = "Calculate inventory value with High Alchemy. By default, the inventory value is calculated using GE price."
     )
-    default boolean useHighAlchemyValue()
-    {
-        return false;
-    }
+    default boolean useHighAlchemyValue() { return false; }
 
     @ConfigItem(
             keyName = "ignoreCoins",
             name = "Ignore Coins",
             description = "Ignore coins in inventory. By default, the inventory value includes coins."
     )
-    default boolean ignoreCoins()
-    {
-        return false;
-    }
-}
+    default boolean ignoreCoins() { return false; }
 
+    @ConfigItem(
+            keyName = "ignoreItems",
+            name = "Ignore Items",
+            description = "Ignore particular items in inventory. By default, no items are ignored."
+    )
+    default String ignoreItems() { return ""; }
+}

--- a/src/main/java/com/wikiworm/inventoryvalue/InventoryValueOverlay.java
+++ b/src/main/java/com/wikiworm/inventoryvalue/InventoryValueOverlay.java
@@ -33,52 +33,44 @@ import net.runelite.client.ui.overlay.components.PanelComponent;
 import net.runelite.client.ui.overlay.components.TitleComponent;
 
 import javax.inject.Inject;
-import javax.swing.*;
-import java.awt.*;
+import javax.swing.SwingUtilities;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
 
-/**
- * The InventoryValueOverlay class is used to display the value of the users inventory as an overlay
- * on the RuneLite client gameplay panel.
- */
-public class InventoryValueOverlay extends Overlay {
+
+public class InventoryValueOverlay extends Overlay
+{
     private Long inventoryValue;
-    private final InventoryValueConfig ivConfig;
+    private final InventoryValueConfig inventoryValueConfig;
     private final PanelComponent panelComponent = new PanelComponent();
 
     @Inject
     private InventoryValueOverlay(InventoryValueConfig config)
     {
-        // TODO -- this should be part of config...
         setPosition(OverlayPosition.ABOVE_CHATBOX_RIGHT);
-        inventoryValue = 0L;
-        ivConfig = config;
+        this.inventoryValue = 0L;
+        this.inventoryValueConfig = config;
     }
 
-    /**
-     * Render the item value overlay.
-     * @param graphics the 2D graphics
-     * @return the value of {@link PanelComponent#render(Graphics2D)} from this panel implementation.
-     */
     @Override
-    public Dimension render(Graphics2D graphics) {
-        String titleText = "Inventory Value:";
-        String valueString = ivConfig.useHighAlchemyValue() ? "HA Price:" : "GE price:";
+    public Dimension render(Graphics2D graphics)
+    {
+        String titleText = "Inventory Value";
+        String valueString = inventoryValueConfig.useHighAlchemyValue() ? "HA Price:" : "GE Price:";
 
-        // Not sure how this can occur, but it was recommended to do so
         panelComponent.getChildren().clear();
 
-        // Build overlay title
         panelComponent.getChildren().add(TitleComponent.builder()
                 .text(titleText)
                 .color(Color.GREEN)
                 .build());
 
-        // Set the size of the overlay (width)
         panelComponent.setPreferredSize(new Dimension(
                 graphics.getFontMetrics().stringWidth(titleText) + 30,
-                0));
+                0
+        ));
 
-        // Build line on the overlay for world number
         panelComponent.getChildren().add(LineComponent.builder()
                 .left(valueString)
                 .right(Long.toString(inventoryValue))
@@ -87,15 +79,8 @@ public class InventoryValueOverlay extends Overlay {
         return panelComponent.render(graphics);
     }
 
-    /**
-     * Updates inventory value display
-     * @param newValue the value to update the InventoryValue's {{@link #panelComponent}} with.
-     */
-    public void updateInventoryValue(final long newValue) {
-        SwingUtilities.invokeLater(() -> {
-            inventoryValue = newValue;
-        });
+    public void updateInventoryValue(final long newValue)
+    {
+        SwingUtilities.invokeLater(() -> inventoryValue = newValue);
     }
-
-
 }

--- a/src/main/java/com/wikiworm/inventoryvalue/InventoryValueOverlay.java
+++ b/src/main/java/com/wikiworm/inventoryvalue/InventoryValueOverlay.java
@@ -26,11 +26,13 @@
  *  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package com.wikiworm.inventoryvalue;
+
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.components.LineComponent;
 import net.runelite.client.ui.overlay.components.PanelComponent;
 import net.runelite.client.ui.overlay.components.TitleComponent;
+import net.runelite.client.util.QuantityFormatter;
 
 import javax.inject.Inject;
 import javax.swing.SwingUtilities;
@@ -73,7 +75,7 @@ public class InventoryValueOverlay extends Overlay
 
         panelComponent.getChildren().add(LineComponent.builder()
                 .left(valueString)
-                .right(Long.toString(inventoryValue))
+                .right(QuantityFormatter.quantityToStackSize(inventoryValue))
                 .build());
 
         return panelComponent.render(graphics);

--- a/src/main/java/com/wikiworm/inventoryvalue/InventoryValuePlugin.java
+++ b/src/main/java/com/wikiworm/inventoryvalue/InventoryValuePlugin.java
@@ -49,7 +49,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.LongStream;
 
-@PluginDescriptor(name = "Inventory Value Tracker")
+@PluginDescriptor(name = "Inventory Value")
 @Slf4j
 public class InventoryValuePlugin extends Plugin
 {

--- a/src/main/java/com/wikiworm/inventoryvalue/InventoryValuePlugin.java
+++ b/src/main/java/com/wikiworm/inventoryvalue/InventoryValuePlugin.java
@@ -28,9 +28,13 @@
 package com.wikiworm.inventoryvalue;
 
 import com.google.inject.Provides;
-import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.*;
+import net.runelite.api.Client;
+import net.runelite.api.InventoryID;
+import net.runelite.api.Item;
+import net.runelite.api.ItemComposition;
+import net.runelite.api.ItemContainer;
+import net.runelite.api.ItemID;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.ItemContainerChanged;
 import net.runelite.client.config.ConfigManager;
@@ -40,17 +44,13 @@ import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
 
+import javax.inject.Inject;
 import java.util.Arrays;
+import java.util.List;
 import java.util.stream.LongStream;
 
-/**
- * The InventoryValuePlugin class is used as the injection point for calculating a user logged into RuneLite client's
- * inventory value.
- */
+@PluginDescriptor(name = "Inventory Value Tracker")
 @Slf4j
-@PluginDescriptor(
-        name = "Inventory Value Overlay"
-)
 public class InventoryValuePlugin extends Plugin
 {
     @Inject
@@ -71,53 +71,61 @@ public class InventoryValuePlugin extends Plugin
     @Override
     protected void startUp() throws Exception
     {
-        // Add the inventory overlay
         overlayManager.add(overlay);
     }
 
     @Override
     protected void shutDown() throws Exception
     {
-        // Remove the inventory overlay
         overlayManager.remove(overlay);
     }
 
     @Subscribe
     public void onGameStateChanged(GameStateChanged gameStateChanged)
     {
-
     }
 
     @Subscribe
     public void onItemContainerChanged(ItemContainerChanged event)
     {
-        if(event.getContainerId() == InventoryID.INVENTORY.getId()) {
-            long inventoryValue = 0;
+        if (event.getContainerId() == InventoryID.INVENTORY.getId())
+        {
+            long inventoryValue;
+            List<String> ignoredItems = buildIgnoredItemsList();
+
             ItemContainer container = client.getItemContainer(InventoryID.INVENTORY);
-            if(container != null) {
+            if (container != null)
+            {
                 Item[] items = container.getItems();
-                inventoryValue = Arrays.stream(items).parallel().flatMapToLong(item -> {
-                    return LongStream.of(calculateItemValue(item));
-                }).sum();
-                // Update the panel
+                inventoryValue = Arrays.stream(items).parallel().flatMapToLong(item ->
+                        LongStream.of(calculateItemValue(item, ignoredItems))).sum();
+
                 overlay.updateInventoryValue(inventoryValue);
             }
         }
     }
 
-    public long calculateItemValue(Item item) {
-        int itemId = item.getId();
-        ItemComposition itemComp = itemManager.getItemComposition(itemId);
-        String itemName = itemComp.getName();
-        int itemValue;
-        // if ignore coins is set, calculate item value as 0
-        if (itemId == ItemID.COINS_995 && config.ignoreCoins())
-            itemValue = 0;
-        else // multiply quantity by HA value or GE value
-            itemValue = item.getQuantity() * (config.useHighAlchemyValue() ? itemComp.getHaPrice() : itemManager.getItemPrice(item.getId()));
-
-        return itemValue;
+    public List<String> buildIgnoredItemsList()
+    {
+        List<String> ignoredItemsList = Arrays.asList(config.ignoreItems().toLowerCase().split("[,;]"));
+        ignoredItemsList.replaceAll(String::trim);
+        return ignoredItemsList;
     }
+
+    public long calculateItemValue(Item item, List<String> ignoredItems)
+    {
+        int itemId = item.getId();
+        ItemComposition itemComposition = itemManager.getItemComposition(itemId);
+        String itemName = itemComposition.getName();
+
+        if ((itemId == ItemID.COINS_995 && config.ignoreCoins()) || ignoredItems.contains(itemName.toLowerCase()))
+        {
+            return 0;
+        }
+        return (long) item.getQuantity() * (config.useHighAlchemyValue() ?
+                itemComposition.getHaPrice() : itemManager.getItemPrice(item.getId()));
+    }
+
     @Provides
     InventoryValueConfig provideConfig(ConfigManager configManager)
     {

--- a/src/test/java/com/wikiworm/inventoryvalue/InventoryValuePluginTest.java
+++ b/src/test/java/com/wikiworm/inventoryvalue/InventoryValuePluginTest.java
@@ -1,0 +1,161 @@
+package com.wikiworm.inventoryvalue;
+
+import com.google.inject.Guice;
+import com.google.inject.testing.fieldbinder.Bind;
+import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import net.runelite.api.Client;
+import net.runelite.api.Item;
+import net.runelite.api.ItemComposition;
+import net.runelite.api.ItemContainer;
+import net.runelite.api.ItemID;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.ui.overlay.OverlayManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class InventoryValuePluginTest
+{
+    @Mock
+    @Bind
+    private Client client;
+
+    @Mock
+    @Bind
+    private ItemManager itemManager;
+
+    @Mock
+    @Bind
+    private InventoryValueConfig config;
+
+    @Mock
+    @Bind
+    private OverlayManager overlayManager;
+
+    @Mock
+    @Bind
+    private ScheduledExecutorService executor;
+
+    @Mock
+    private File file;
+
+
+    @Inject
+    InventoryValuePlugin inventoryValuePlugin;
+
+    @Mock
+    ItemContainer itemContainer;
+
+    @Mock
+    ItemComposition itemComposition;
+
+    Item coins;
+    Item testItem;
+
+    String ignoredItemsConfig;
+    List<String> ignoredItemsList;
+    int itemId;
+    int quantity;
+
+    @Before
+    public void before()
+    {
+        Guice.createInjector(BoundFieldModule.of(this)).injectMembers(this);
+    }
+
+    @Test
+    public void testBuildIgnoredItemsList()
+    {
+        // split on comma, ignore leading whitespace
+        String ignoreItemsString = "foo, bar";
+        when(config.ignoreItems()).thenReturn(ignoreItemsString);
+
+        assertEquals(Arrays.asList("foo", "bar"), inventoryValuePlugin.buildIgnoredItemsList());
+
+        // split on comma or semicolon, ignore trailing whitespace
+        String ignoreItemsStringWithSemicolon = "foo,bar;baz ";
+        when(config.ignoreItems()).thenReturn(ignoreItemsStringWithSemicolon);
+
+        assertEquals(Arrays.asList("foo", "bar", "baz"), inventoryValuePlugin.buildIgnoredItemsList());
+
+        String ignoreItemsStringWithCasing = "FOo, BaR; BAZ";
+        when(config.ignoreItems()).thenReturn(ignoreItemsStringWithCasing);
+
+        assertEquals(Arrays.asList("foo", "bar", "baz"), inventoryValuePlugin.buildIgnoredItemsList());
+    }
+
+    public void coinsValueTestSetup()
+    {
+        itemId = ItemID.COINS_995;
+        quantity = 3201;
+        coins = new Item(itemId, quantity);
+        ignoredItemsList = Collections.emptyList();
+
+        when(itemComposition.getName()).thenReturn("Coins");
+        when(itemManager.getItemPrice(itemId)).thenReturn(1);
+        when(itemManager.getItemComposition(itemId)).thenReturn(itemComposition);
+    }
+
+    @Test
+    public void testCoinsIgnoredWhenIgnoreCoinsIsSet()
+    {
+        coinsValueTestSetup();
+
+        when(config.ignoreCoins()).thenReturn(true);
+
+        assertEquals(0, inventoryValuePlugin.calculateItemValue(coins, ignoredItemsList));
+    }
+
+    @Test
+    public void testCoinsNotIgnoredWhenIgnoreCoinsIsNotSet()
+    {
+        coinsValueTestSetup();
+
+        when(config.ignoreCoins()).thenReturn(false);
+
+        assertEquals(quantity, inventoryValuePlugin.calculateItemValue(coins, ignoredItemsList));
+    }
+
+    public void ignoreItemTestSetup(int itemId, String itemName, int itemValue)
+    {
+        quantity = 1;
+        testItem = new Item(itemId, quantity);
+        ignoredItemsConfig = "Bottomless compost bucket, Leather chaps";
+        ignoredItemsList = Arrays.asList("bottomless compost bucket", "leather chaps");
+
+        when(itemComposition.getName()).thenReturn(itemName);
+        when(itemManager.getItemPrice(itemId)).thenReturn(itemValue);
+        when(itemManager.getItemComposition(itemId)).thenReturn(itemComposition);
+    }
+
+    @Test
+    public void testItemNotIgnoredWhenNotInIgnoredItems()
+    {
+        int testItemValue = 40000000;
+        ignoreItemTestSetup(ItemID.SARADOMIN_GODSWORD, "Saradomin godsword", testItemValue);
+
+        assertEquals(testItemValue, inventoryValuePlugin.calculateItemValue(testItem, ignoredItemsList));
+    }
+
+    @Test
+    public void testItemIgnoredWhenInIgnoredItems()
+    {
+        int testItemValue = 300000;
+        ignoreItemTestSetup(ItemID.BOTTOMLESS_COMPOST_BUCKET, "Bottomless compost bucket", testItemValue);
+
+        assertEquals(0, inventoryValuePlugin.calculateItemValue(testItem, ignoredItemsList));
+    }
+}

--- a/src/test/java/com/wikiworm/inventoryvalue/InventoryValueTest.java
+++ b/src/test/java/com/wikiworm/inventoryvalue/InventoryValueTest.java
@@ -27,13 +27,8 @@
  */
 package com.wikiworm.inventoryvalue;
 
-import net.runelite.api.Item;
-import net.runelite.api.ItemID;
 import net.runelite.client.RuneLite;
 import net.runelite.client.externalplugins.ExternalPluginManager;
-import net.runelite.client.game.ItemManager;
-import org.junit.Assert;
-import org.junit.Test;
 
 public class InventoryValueTest
 {


### PR DESCRIPTION
Configuration options:
ignoreCoins -- coins will no longer be shown in total value
useHaValue -- use the high alchemy value of an item instead of the GE price
ignoreItems -- list of item names, case-insensitive, delimited by either comma or semicolon

![image](https://user-images.githubusercontent.com/5294864/102701144-eea3d380-4221-11eb-9b66-bbb6d91408b3.png)

Allows a user to see value fluctuation in a farm run, supplies used vs drops gained, and many other scenarios.

![image](https://user-images.githubusercontent.com/5294864/102701170-33c80580-4222-11eb-92f3-a1efebc0e8a8.png)


With the addition of the ignoreItems configuration, items in your inventory used for a kill which are not consumable can be ignored, allowing an easier tally of the overall gp gain from a trip.
![image](https://user-images.githubusercontent.com/5294864/102701261-2b23ff00-4223-11eb-97c6-0ccc197d2896.png)

![image](https://user-images.githubusercontent.com/5294864/102736363-bcbe6a00-4312-11eb-8417-bf0d69f517ac.png)

