### PR TITLE
Fix world hopping bug

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
     mavenCentral()
 }
 
-def runeLiteVersion = '1.6.35'
+def runeLiteVersion = '1.7.1'
 
 dependencies {
     compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/wikiworm/inventoryvalue/InventoryValueOverlay.java
+++ b/src/main/java/com/wikiworm/inventoryvalue/InventoryValueOverlay.java
@@ -48,16 +48,14 @@ public class InventoryValueOverlay extends Overlay
     private final PanelComponent panelComponent = new PanelComponent();
 
     @Inject
-    private InventoryValueOverlay(InventoryValueConfig config)
-    {
+    private InventoryValueOverlay(InventoryValueConfig config) {
         setPosition(OverlayPosition.ABOVE_CHATBOX_RIGHT);
         this.inventoryValue = 0L;
         this.inventoryValueConfig = config;
     }
 
     @Override
-    public Dimension render(Graphics2D graphics)
-    {
+    public Dimension render(Graphics2D graphics) {
         String titleText = "Inventory Value";
         String valueString = inventoryValueConfig.useHighAlchemyValue() ? "HA Price:" : "GE Price:";
 
@@ -81,8 +79,7 @@ public class InventoryValueOverlay extends Overlay
         return panelComponent.render(graphics);
     }
 
-    public void updateInventoryValue(final long newValue)
-    {
+    public void updateInventoryValue(final long newValue) {
         SwingUtilities.invokeLater(() -> inventoryValue = newValue);
     }
 }

--- a/src/main/java/com/wikiworm/inventoryvalue/InventoryValuePlugin.java
+++ b/src/main/java/com/wikiworm/inventoryvalue/InventoryValuePlugin.java
@@ -29,12 +29,7 @@ package com.wikiworm.inventoryvalue;
 
 import com.google.inject.Provides;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.Client;
-import net.runelite.api.InventoryID;
-import net.runelite.api.Item;
-import net.runelite.api.ItemComposition;
-import net.runelite.api.ItemContainer;
-import net.runelite.api.ItemID;
+import net.runelite.api.*;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.ItemContainerChanged;
 import net.runelite.client.config.ConfigManager;
@@ -69,35 +64,29 @@ public class InventoryValuePlugin extends Plugin
     private InventoryValueOverlay overlay;
 
     @Override
-    protected void startUp() throws Exception
-    {
+    protected void startUp() throws Exception {
         overlayManager.add(overlay);
     }
 
     @Override
-    protected void shutDown() throws Exception
-    {
+    protected void shutDown() throws Exception {
         overlayManager.remove(overlay);
     }
 
     @Subscribe
-    public void onGameStateChanged(GameStateChanged gameStateChanged)
-    {
+    public void onGameStateChanged(GameStateChanged gameStateChanged) {
     }
 
     @Subscribe
-    public void onItemContainerChanged(ItemContainerChanged event)
-    {
-        if (event.getContainerId() == InventoryID.INVENTORY.getId())
-        {
+    public void onItemContainerChanged(ItemContainerChanged event) {
+        if (event.getContainerId() == InventoryID.INVENTORY.getId()) {
             long inventoryValue;
             List<String> ignoredItems = buildIgnoredItemsList();
 
             ItemContainer container = client.getItemContainer(InventoryID.INVENTORY);
-            if (container != null)
-            {
+            if (container != null) {
                 Item[] items = container.getItems();
-                inventoryValue = Arrays.stream(items).parallel().flatMapToLong(item ->
+                inventoryValue = Arrays.stream(items).flatMapToLong(item ->
                         LongStream.of(calculateItemValue(item, ignoredItems))).sum();
 
                 overlay.updateInventoryValue(inventoryValue);
@@ -105,22 +94,19 @@ public class InventoryValuePlugin extends Plugin
         }
     }
 
-    public List<String> buildIgnoredItemsList()
-    {
+    public List<String> buildIgnoredItemsList() {
         List<String> ignoredItemsList = Arrays.asList(config.ignoreItems().toLowerCase().split("[,;]"));
         ignoredItemsList.replaceAll(String::trim);
         return ignoredItemsList;
     }
 
-    public long calculateItemValue(Item item, List<String> ignoredItems)
-    {
+    public long calculateItemValue(Item item, List<String> ignoredItems) {
         int itemId = item.getId();
         if(itemManager != null) {
             ItemComposition itemComposition = itemManager.getItemComposition(itemId);
             String itemName = itemComposition.getName();
 
-            if ((itemId == ItemID.COINS_995 && config.ignoreCoins()) || ignoredItems.contains(itemName.toLowerCase()))
-            {
+            if ((itemId == ItemID.COINS_995 && config.ignoreCoins()) || ignoredItems.contains(itemName.toLowerCase())) {
                 return 0L;
             }
             return (long) item.getQuantity() * (config.useHighAlchemyValue() ?
@@ -128,12 +114,10 @@ public class InventoryValuePlugin extends Plugin
         } else {
             return 0L;
         }
-
     }
 
     @Provides
-    InventoryValueConfig provideConfig(ConfigManager configManager)
-    {
+    InventoryValueConfig provideConfig(ConfigManager configManager) {
         return configManager.getConfig(InventoryValueConfig.class);
     }
 }

--- a/src/test/java/com/wikiworm/inventoryvalue/InventoryValuePluginTest.java
+++ b/src/test/java/com/wikiworm/inventoryvalue/InventoryValuePluginTest.java
@@ -106,8 +106,7 @@ public class InventoryValuePluginTest
     }
 
     @Test
-    public void testBuildIgnoredItemsList()
-    {
+    public void testBuildIgnoredItemsList() {
         // split on comma, ignore leading whitespace
         String ignoreItemsString = "foo, bar";
         when(config.ignoreItems()).thenReturn(ignoreItemsString);
@@ -126,8 +125,7 @@ public class InventoryValuePluginTest
         assertEquals(Arrays.asList("foo", "bar", "baz"), inventoryValuePlugin.buildIgnoredItemsList());
     }
 
-    public void coinsValueTestSetup()
-    {
+    public void coinsValueTestSetup() {
         itemId = ItemID.COINS_995;
         quantity = 3201;
         coins = new Item(itemId, quantity);
@@ -139,8 +137,7 @@ public class InventoryValuePluginTest
     }
 
     @Test
-    public void testCoinsIgnoredWhenIgnoreCoinsIsSet()
-    {
+    public void testCoinsIgnoredWhenIgnoreCoinsIsSet() {
         coinsValueTestSetup();
 
         when(config.ignoreCoins()).thenReturn(true);
@@ -149,8 +146,7 @@ public class InventoryValuePluginTest
     }
 
     @Test
-    public void testCoinsNotIgnoredWhenIgnoreCoinsIsNotSet()
-    {
+    public void testCoinsNotIgnoredWhenIgnoreCoinsIsNotSet() {
         coinsValueTestSetup();
 
         when(config.ignoreCoins()).thenReturn(false);
@@ -158,8 +154,7 @@ public class InventoryValuePluginTest
         assertEquals(quantity, inventoryValuePlugin.calculateItemValue(coins, ignoredItemsList));
     }
 
-    public void ignoreItemTestSetup(int itemId, String itemName, int itemValue)
-    {
+    public void ignoreItemTestSetup(int itemId, String itemName, int itemValue) {
         quantity = 1;
         testItem = new Item(itemId, quantity);
         ignoredItemsConfig = "Bottomless compost bucket, Leather chaps";
@@ -171,8 +166,7 @@ public class InventoryValuePluginTest
     }
 
     @Test
-    public void testItemNotIgnoredWhenNotInIgnoredItems()
-    {
+    public void testItemNotIgnoredWhenNotInIgnoredItems() {
         int testItemValue = 40000000;
         ignoreItemTestSetup(ItemID.SARADOMIN_GODSWORD, "Saradomin godsword", testItemValue);
 
@@ -180,8 +174,7 @@ public class InventoryValuePluginTest
     }
 
     @Test
-    public void testItemIgnoredWhenInIgnoredItems()
-    {
+    public void testItemIgnoredWhenInIgnoredItems() {
         int testItemValue = 300000;
         ignoreItemTestSetup(ItemID.BOTTOMLESS_COMPOST_BUCKET, "Bottomless compost bucket", testItemValue);
 


### PR DESCRIPTION
Issue was caused by incorrect usage of ItemManager. ItemManager is designed to be called only from the client thread. The ItemManager.getItemComposition function will assert if the function is called from a non-client thread.
Fixed some formatting.